### PR TITLE
Remove reliance upon non-portable magic numbers

### DIFF
--- a/file io/sum.md
+++ b/file io/sum.md
@@ -38,9 +38,9 @@ int main(int argc, char* argv[])
 
 int to_int(int c)
 {
-    if (c >= 48 && c <= 57)
+    if (c >= '0' && c <= '9')
     {
-        return c - 48;
+        return c - '0';
     }
     else
     {


### PR DESCRIPTION
While I get that you intend to teach C on systems that are primarily ASCII, it makes no sense to embed this non-portable code-rot into an exercise. It's a much better idea to set the example of using a character constant here. The benefit is not just in portability, but also in code maintenance; those numbers mean nothing to us as maintainers, where-as the character constants, we *should* know exactly what they mean by this point...